### PR TITLE
Next release

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -9,6 +9,7 @@
   "dependencies": {
     "mute": [
       "commitizen",
+      "eslint-plugin-json",
       "joi"
     ]
   },

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -28,7 +28,11 @@ plugins:
     - 184efb4b1212345dcbe0bf36064230f4
     - c03f7976bb3e27eb1e08b08d0475a15b
     # Trailing question mark in heading.
-    - 299b8b7c47d3644f029ad29866c9e5b0
+    - 82098ef96fff43e6c43f874f768ef70c
+    # Spaces surrounding link text (wronly reported).
+    - f1d8f1048cbd287f2c5696a297926243
+    # Bare URL inside contributor covenant code of conduct (automated).
+    - 13fb507303344d8bd75055a4630ca70b
   # Requires a `shrinkwrap.json` at the project root to work!
   # So we'll rely on the cloud check by NodeSecurity.io.
   nodesecurity:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at cgalvarez.engineer@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">AtomCoverage</h1>
-<h3 align="center">Add code coverage to your ES6 Atom package</h3>
+<h3 align="center">Add code coverage to your Atom package</h3>
 <p align="center">
   <a href="https://nodei.co/npm/atom-coverage/">
     <img src="https://nodei.co/npm/atom-coverage.png">
@@ -31,14 +31,19 @@
     <img src="https://img.shields.io/badge/commitizen-friendly-brightgreen.svg?style=flat"
       alt="Commitizen friendly" />
   </a>
-  <a href="https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines">
-    <img src="https://img.shields.io/badge/follow-angular%20commit%20convention-blue.svg"
-      alt="Follow angular commit convention" />
-  </a>
   <a href="https://semantic-release.gitbooks.io/semantic-release/content/">
     <img
       src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg"
       alt="Semantic release" />
+  </a>
+  <br />
+  <a href="https://github.com/cgalvarez/atom-coverage/blob/master/CODE_OF_CONDUCT.md">
+    <img src="https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat"
+      alt="Code of conduct" />
+  </a>
+  <a href="https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines">
+    <img src="https://img.shields.io/badge/follow-angular%20commit%20convention-blue.svg"
+      alt="Follow angular commit convention" />
   </a>
 </p>
 <p align="center">
@@ -79,22 +84,18 @@
       alt="bitHound Code" />
   </a>
   <br />
-  <!--<a href="https://codeclimate.com/github/cgalvarez/atom-coverage">
-    <img src="https://codeclimate.com/github/cgalvarez/atom-coverage/badges/issue_count.svg"
-      alt="CodeClimate issue count" />-->
-  </a>
-  <a href="https://codeclimate.com/github/cgalvarez/atom-coverage/issues">
-    <img src ="https://img.shields.io/codeclimate/issues/github/cgalvarez/atom-coverage.svg?label=Code%20Climate%20issues"
-      alt="Code Climate issues" />
-  </a>
   <a href="https://codeclimate.com/github/cgalvarez/atom-coverage/maintainability">
     <img src="https://api.codeclimate.com/v1/badges/dd177b97982f224495c4/maintainability"
       alt="CodeClimate maintainability score" />
   </a>
-  <br />
   <a href="https://codeclimate.com/github/cgalvarez/atom-coverage/test_coverage">
     <img src="https://api.codeclimate.com/v1/badges/dd177b97982f224495c4/test_coverage"
       alt="CodeClimate test coverage " />
+  </a>
+  <br />
+  <a href="https://codeclimate.com/github/cgalvarez/atom-coverage/issues">
+    <img src ="https://img.shields.io/codeclimate/issues/github/cgalvarez/atom-coverage.svg?label=Code%20Climate%20issues"
+      alt="Code Climate issues" />
   </a>
   <a href="https://codecov.io/gh/cgalvarez/atom-coverage">
     <img src="https://codecov.io/gh/cgalvarez/atom-coverage/branch/master/graph/badge.svg"
@@ -118,61 +119,41 @@
   </a>
 </p>
 
-AtomCoverage allows you to perform code coverage analysis on your Atom package
-by means of `istanbul/nyc`.
+Currently **only** the following languages/frameworks are supported:
 
-This package aims to be a quick patch to get you up and running with code
-coverage by addressing some awkward pitfalls when integrating `nyc` with Atom
-packages.
+- Languages:
+  - ES6 (ECMAScript2015)
+- Testing frameworks:
+  - [`mocha`](https://mochajs.org/)
+  (through [`atom-mocha`](https://www.npmjs.com/package/atom-mocha))
+- Coverage frameworks:
+  - [`nyc`](https://istanbul.js.org/)
 
-The requirements (or current limitations, if you prefer) for AtomCoverage to
-work are:
-
-- Your Atom package must be coded in JavaScript ES6.
-- Your Atom package specs must use [`mocha`](https://mochajs.org/)
-  (by means of [`atom-mocha`](https://www.npmjs.com/package/atom-mocha)).
-- You are limited to the [`istanbul/nyc`](https://istanbul.js.org/) coverage
-  framework.
-
-Why? Because those are the frameworks I'm actively testing due to my own needs.
-[Feel free to contribute](#faq) and improve this package to work with other
-testing/coverage frameworks. It is designed to be easily extended.
+[Feel free (and encouraged!) to contribute](#faq) and improve this package to
+work with other languages/frameworks!
 
 ## Quickstart
 
 ```shell
-           $ cd your-atom-pkg
-           # Choose one of the following depending on your package manager.
-[CHOICE 1] $ npm install babel-cli babel-core babel-plugin-istanbul babel-preset-env nyc atom-mocha atom-coverage --save-dev
-[CHOICE 2] $ yarn add babel-cli babel-core babel-plugin-istanbul babel-preset-env nyc atom-mocha atom-coverage --dev
-           $ (npm|yarn) run test:coverage
+$ cd your-atom-pkg
+$ npm install babel-cli babel-core babel-plugin-istanbul \
+  babel-preset-env nyc atom-mocha atom-coverage --save-dev
+$ npm run test:coverage
 ```
 
-That easy? **Yes**, seriously. AtomCoverage...
+After installing, you'll have two new NPM scripts (won't be overwritten if
+already present):
 
-- makes NPM warning you about missing peer dependencies (the ones you've just
-  installed with the quickstart commands above!).
-- leverages the `postinstall` hook by adding (if not exists) next NPM scripts
-  to the `package.json` of your Atom package automagically for you:
-  - `test:coverage`: runs your specs and generates code coverage reports on
-    finish.
-  - `check:coverage`: checks if your coverage is above your thresholds. Read
-    [here](https://github.com/istanbuljs/nyc#checking-coverage) how to
-    configure them in your `.nycrc(.json)?`.
-- checks automagically the existence and correct settings for both, `babel` and
-  `nyc` in their respective config files (`.babelrc`, `.nycrc(.json)?`); if any
-  of them is missing or has an incorrect configuration, it will automatically
-  create them or solve the conflicts for you (*to some extent, of course*; read
-  the caveats at [Configuration files section](#configuration-files) below).
+- `test:coverage`: runs your specs and generates code coverage reports on
+  finish.
+- `check:coverage`: checks if your coverage is above your thresholds. Read
+  [how to configure thresholds with `nyc`](https://github.com/istanbuljs/nyc#checking-coverage).
 
-I recommend you that you define your NPM `test` script as
-`"test": "cross-env NODE_ENV=test atom --test spec/*.spec.js spec/**/*.spec.js"`.
-`apm test` does not allow for subdirectories, as opposed to `atom --test`, but
-it needs the two patterns, as `**/*` only takes charge of any subfolder(s), but
-not the files on the root folder.
-
-I prefer having subfolders because I can classify my tests into unit, functional,
-integration or acceptance tests.
+I strongly recommend you to define your tests script as
+`cross-env NODE_ENV=test atom --test spec/*.spec.js spec/**/*.spec.js`.
+`apm test` does not allow for subdirectories, as opposed to `atom --test`.
+Having subfolders allows a clearer, properly scoped structure for your
+tests/specs.
 
 > **NOTE**: `atom --test spec/*.js` will fail if no `.js` files present at
 `spec/`, and `atom --test spec/**/*.js` will fail if no `.js` files present in
@@ -180,124 +161,45 @@ any subfolder under `spec/`. This has nothing to do with AtomMocha, but Atom
 itself, so define your `test` script congruently/coherently with your project
 structure.
 
-## How to require your *modules under test* (`mut` from here on)
-
-AtomCoverage wraps your `npm test` command to get the code coverage. It doesn't
-make any magic to infer how to test your specs. You must define that in your NPM
-`test` script.
-
-You need to `require()` your pre-instrumented files instead your source files
-inside your tests/specs for the code coverage to work, but this would break your
-tests when running without coverage (in that case you should only request your
-source files). That's why this package exports an alternative `require()` called
-`testquire()`, which loads your source files or the pre-instrumented ones,
-depending if you request code coverage (loads pre-instrumented) or or not
-(loads source files). You don't need to configure anything. It resolves both
-cases automatically for you. The only thing you need inside your tests/specs is:
-
-```javascript
-const { testquire } = require('atom-coverage');
-const mut = testquire('path/relative/to/sources/root/for/mut');
-```
-
----
-
-**Example**: Let's assume you keep your source files under `lib/`, and you want
-to load a module placed at `lib/folder1/folder2/mod.js`. Then you will require
-it as follows:
-
-```javascript
-const { testquire } = require('atom-coverage');
-const mut = testquire('folder1/folder2/mod');
-```
-
-If you run `npm test`, `testquire` will require your source file at
-`lib/folder1/folder2/mod.js`.
-
-If you run `npm run test:coverage`, `testquire` will require your instrumented
-file at `coverage/.instrumented/folder1/folder2/mod.js` (assuming that you're
-using the default options).
-
----
-
-What if you want to stub some of your modules inside your instrumented files
-with the awesome [`proxyquire`](https://www.npmjs.com/package/proxyquire)
-package? Then you'll need the path to your instrumented files to inject the
-stubs, but hardcoding the paths would be unmaintainable (and it would break
-running only your specs, in addition). That's why you can pass a second
-parameter `requireIt` to `testquire()`, which manages whether 1) to require
-the file and return it (`true`) or 2) not (`false`). So you could use
-proxyquire as follows:
-
-```javascript
-const { testquire } = require('atom-coverage');
-const proxyquire = require('proxyquire');
-const mutPath = testquire('folder1/folder2/mod', false);
-const anotherModStub = {};
-const mut = proxyquire(mutPath, {
-  './anotherMod': anotherModStub,
-});
-```
-
-> **NOTE**: Requiring NodeJS core modules or project NPM dependencies is done
-as usual (i.e., `require('fs')` or `require('npmPackage')`).
-
 ## Configuration files
 
-This package leverages some other awesome projects to perform the code coverage,
-and uses their configuration files:
+`atom-coverage` uses the config files of the involved frameworks if present.
+If any of them is missing or has an incorrect configuration, it will
+automatically create them or solve the conflicts for you (*to some extent, of
+course*).
 
-- [`babel`](http://babeljs.io/) ~> AtomCoverage inherits the config in
-  [`${your-atom-pkg}/.babelrc`](https://babeljs.io/docs/usage/babelrc/) to
-  transpile your Atom ES6 project into ES5 JavaScript.
-- [`nyc`](https://istanbul.js.org/) ~> AtomCoverage inherits the config in
-  [`${your-atom-pkg}/.nycrc(.json)?`](https://github.com/istanbuljs/nyc/blob/master/lib/config-util.js)
-- [`atom-mocha`](https://www.npmjs.com/package/atom-mocha).
+Assuming `atom-pkg/` is the root folder of your Atom package, let's dig into
+each config file...
 
-Let's dig into each config file...
+### `atom-pkg/.atom-coverage(.(json|yaml|yml))?`
 
-### `.babelrc`
+This is the configuration file for `atom-coverage` itself. You can also provide
+this configuration through the property `atomCoverage` inside your Atom
+package's `package.json`.
 
-You can learn about how `babel` looks up `.babelrc` (or even setting the config
-inside your `package.json`)
-[here](https://babeljs.io/docs/usage/babelrc/#lookup-behavior). I strongly
-recommend you to keep `babel` config it its own `.babelrc` at your project root.
+The list of currently supported options are:
 
-The minimum required configuration in your `.babelrc` is:
+Option|Type|Description|Default|Valid
+-|-|-|-|-
+`instrumenter`|String|The coverage framework to use|`nyc`|`nyc`
+`transpiler`|String|The transpiler to use|`babel`|`babel`
+`sourcesRoot`|String|The relative path to the root of your Atom package's source files|`lib/`<br />`src/`|-
+`testScript`|Script|The NPM script to execute your tests and get them covered with the configured `instrumenter`|`test`|-
 
-```json
-{
-  "env": {
-    "test": {
-      "plugins": ["istanbul"],
-      "sourceMaps": "inline"
-    }
-  },
-  "presets": ["env"]
-}
-```
+### [`atom-pkg/.babelrc`](https://babeljs.io/docs/usage/babelrc/)
 
-Please, note that if you need any extra plugin(s) to support the ES6 features of
-your Atom project, you will need to install/add those plugins to your project
-`devDependencies` and modify the `env.test.plugins` entry to make it
-successfully transpiling your code.
+This is the configuration file for [`babel`](http://babeljs.io/), which
+`atom-coverage` uses to transpile your ES6 code into ES5 that `nyc` understands.
+The minimum required configuration is:
 
-**Example**: if your package uses decorators, you will need the babel plugin
-`babel-plugin-transform-decorators-legacy`, so you will execute one of:
-
-```shell
-[CHOICE 1] npm install --save-dev babel-plugin-transform-decorators-legacy
-[CHOICE 2] yarn add babel-plugin-transform-decorators-legacy --dev
-```
-
-And you will modify `.babelrc` as follows:
-
-```json
+```javascript
 {
   "env": {
     "test": {
       "plugins": [
-        "transform-decorators-legacy",
+        // You must install as devDep any babel plugin that your Atom package
+        // requires to get successfully transpiled, and include it here
+        "...",
         "istanbul"
       ],
       "sourceMaps": "inline"
@@ -307,87 +209,116 @@ And you will modify `.babelrc` as follows:
 }
 ```
 
-> **NOTE 1**: In case you need help with this, please, refer to
-> the [plugins section](https://babeljs.io/docs/plugins/) on the babel site to
-> learn how to use them, as that is not a problem related with this package.
+Helpful links:
+
+- [`.babelrc` reference](https://babeljs.io/docs/usage/babelrc/)
+- [Babel plugins reference](https://babeljs.io/docs/plugins/)
+
+> **NOTE 1**: The order of the Babel plugins **matters**, so you must find the
+> correct order for your code to get transpiled, **being `istanbul` always the
+> last one** (AtomCoverage enforces this).
 >
-> **NOTE 2**: Notice that the order of the plugins **matters**, so you must
-> find the correct order for your Atom package, **being `"istanbul"` always the
-> last one** (AtomCoverage ensures this last one).
+> **NOTE 2**: `atom-coverage` does **NOT** currently support Babel config in
+> `package.json`.
 
-### `.nycrc(.json)?`
+### `atom-pkg/.nycrc(.json)?`
 
-Didn't get `babel-plugin-istanbul` to work with on-the-fly instrumentation, so
-all source files are pre-instrumented.
+This is the configuration file for [`nyc`](https://istanbul.js.org/), which
+`atom-coverage` uses to analyze the code coverage of your pre-instrumented files.
 
-AtomCoverage inherits your `nyc` settings. If you want to learn about them, please,
-[dig into the relevant piece of its code](https://github.com/istanbuljs/nyc/blob/master/lib/config-util.js),
-read [the official docs at its site](https://istanbul.js.org/) or get command
-line help with `./node_modules/.bin/nyc --help`.
+Some `nyc` options don't work when pre-instrumenting source files. You don't
+need to care about this, since `atom-coverage` fixes them for you! The list of
+fixed options includes (but is not limited to, since I haven't thoroughly tested
+all options):
 
-That said, some `nyc` options doesn't work when pre-instrumenting source files
-(which this package does), including but not limited (haven't thoroughly tested
-all of them) to:
+- `include: String[]`: array of
+  [`glob`-compliant](https://www.npmjs.com/package/glob#glob-primer) strings.
+  If you provide a folder instead of a glob (i.e., `lib` or `lib/`), it
+  will be extended to recursively get all JavaScript files in that folder
+  (previous example would be extended to `lib/**/*.js`).
+- `all: boolean`: set `all=true` inside your `nyc` config file to recursively,
+  automagically get all your source files under `sourcesRoot` folder included
+  and covered.
 
-#### `include`
+Helpful links:
 
-The **GOOD NEWS** are that AtomCoverage fixes this functionality. Now you can
-provide **an array of [`glob`-compliant](https://www.npmjs.com/package/glob#glob-primer)
-globs**. If you provide a folder instead a glob (i.e., `'lib'` or `'lib/'`), it
-will be extended to get all JavaScript files in that folder (following the same
-  example, it would be extended to `'lib/**/*.js'`).
+- [`nyc` official site](https://istanbul.js.org/)
+- [`nyc` code](https://github.com/istanbuljs/nyc/blob/master/lib/config-util.js)
+  for its settings API
 
-#### `all`
+> **NOTE**: `atom-coverage` does **NOT** currently support `nyc` config in
+> `package.json`.
 
-When pre-instrumenting your source files, the `all` option becomes
-[useless](https://github.com/istanbuljs/nyc/issues/594).
+## `testquire(uutPath: string, requireIt: boolean = true)`
 
-Again, the **GOOD NEWS** are that AtomCoverage fixes it for you too! If you set
-`all=true` inside your `.nycrc` file, you will get automagically **all** your
-JavaScript source files under `(lib|src)/` folder (recursively) added and
-covered.
+We will refer to you files/modules as *UUT* (*Units Under Test*) from here on.
 
-## FAQ
+AtomCoverage wraps your NPM test command to analyze the code coverage based on
+your package tests. It doesn't make any magic to infer how to test your specs.
+You must define that in an NPM script, given by the option `testScript` (which
+defaults to `test` script if not provided).
 
-### Does/will this package support ***MY_CHOICE*** testing/coverage framework?
+You need to `require()` your pre-instrumented files instead your source files
+inside your tests/specs for the code coverage to work, but this would break your
+tests when running without coverage (in that case you should only request your
+source files). That's why this package exports an alternative `require()` called
+`testquire()`, which loads your source files or the pre-instrumented ones,
+depending if you request code coverage (thus loading pre-instrumented files) or
+not (thus loading source files). You don't need to configure anything. It
+resolves both cases automatically for you. The only thing you need inside your
+tests/specs is:
 
-Currently only supports `mocha` test runner by means of `atom-mocha` (with the
-assertion library of your choice), and `istanbul` coverage through `nyc`.
+```javascript
+const { testquire } = require('atom-coverage');
+const uut = testquire('path/relative/to/sources/root/for/uut');
+```
 
-If you want to support a different testing/coverage framework, please, help
-other developers with the same needs/preferences as you :blush:, help the open
-source community :heart: and contribute to the project by making an awesome pull
-request! :sparkles:
+> **NOTE**: You don't need to care about the depth level of your source/test
+> files! `atom-coverage` automatically takes charge of that for you too!
 
-I think it should not be very cumbersome to include support for other transpiled
-languages, like CoffeScript (which Atom supports right out-of-the-box) or
-TypeScript (this one would need some extra work, since
-[it isn't supported directly by Atom](https://discuss.atom.io/t/support-run-package-wrote-in-typescript/50333/7)),
-by transpiling them with their own compilers in the transpilation stage.
+### Example
 
-Regarding other coverage frameworks, the only one I have experience with is the
-one currently implemented, so you will likely be on your own.
+Let's assume you keep your source files under `lib/`, and you want
+to load a file placed at `lib/folder1/folder2/file.js`. Then you require it
+inside your test/spec as:
 
-Regarding other testing frameworks, I know Atom ships with `jasmine` support,
-but like I've just said above, I have no direct experience with it, so my help
-will be very limited.
+```javascript
+const { testquire } = require('atom-coverage');
+const uut = testquire('folder1/folder2/file');
+```
 
-## Some ideas for future development
+If you run `npm test`, `testquire()` will require your source file at
+`lib/folder1/folder2/file.js`.
 
-- [ ] Implement CD (Continuous Development) feedback through NPM script
-  `test:coverage:watch` by instrumenting/covering on-the-fly only modified
-  source files and re-running `nyc`.
-- [ ] Create a NPM script to open HTML coverage reports in the browser after
-  being generated.
-- [ ] Inject code to leverage from [`browsersync`](https://browsersync.io/)
-  into the HTML coverage reports to refresh automatically on re-generation.
-- [ ] Maybe other languages?
-- [ ] Use [Benbria CoffeeCoverage](https://github.com/benbria/coffee-coverage)
-  to cover Atom projects written in CoffeeScript.
-- [ ] Use [`codependency`](https://www.npmjs.com/package/codependency) or
-  [`optional`](https://www.npmjs.com/package/optional) to manage optional peer
-  dependencies (when extending to other frameworks; i.e. `babel`, `nyc`,
-  `coffeescript`, `typescript`,...).
+If you run `npm run test:coverage`, `testquire` will require your instrumented
+file at `coverage/.instrumented/folder1/folder2/file.js` (assuming that you're
+using the default options for `nyc` and `atom-coverage`).
+
+### Stubbing your UUT's dependencies
+
+What if you want to stub some of your files/modules inside your instrumented
+files? You can do that with the awesome
+[`proxyquire`](https://www.npmjs.com/package/proxyquire) package.
+
+You need to feed `proxyquire()` with the path to your instrumented files to
+inject your stubs, but hardcoding the paths would be unmaintainable (and it
+would break running only your specs, in addition). That's why you can pass a
+second parameter `requireIt` to `testquire()`, which manages whether (1) to
+require the file and return it (`requireIt=true`) or (2) not (`requireIt=false`).
+So you could use `proxyquire` as follows:
+
+```javascript
+const { testquire } = require('atom-coverage');
+const proxyquire = require('proxyquire');
+const uutPath = testquire('folder1/folder2/file', false);
+const uutDepStub = {};
+const uut = proxyquire(uutPath, {
+  'path/to/dep/exactly/as/required/inside/uut': uutDepStub,
+});
+```
+
+> **NOTE**: Requiring NodeJS core modules or external dependencies is done
+as usual (i.e., `require('fs')` or `require('npmPackage')`).
 
 ## Contributing
 
@@ -407,15 +338,24 @@ $ git remote add upstream https://github.com/cgalvarez/atom-coverage
 $ git checkout -m 'your-pr-topic'
 # 05. Choose on command to install the package dependencies based on
 #     your package manager.
-$ yarn / npm install
+$ (yarn|npm) install
 # 06. Make your changes and write specs to test them.
 # 07. Ensure that your changes pass the project requirements
 #     (linting, tests, coverage...).
-$ npm run prepush
+$ npm run check
 # 08. Once you've finished, commit your changes with commitizen.
 $ npm run semantic-commit
 # 09. Send a pull request describing what you have done.
 ```
+
+## FAQ
+
+### Does/will this package support my desired testing/coverage framework?
+
+If you want to support a different testing/coverage framework, please, help
+other developers with the same needs/preferences/desires as you :blush:, help
+the open source community :heart: and contribute to the project by making an
+awesome pull request! :sparkles:
 
 ## Author
 

--- a/lib/instrumenter/nyc.js
+++ b/lib/instrumenter/nyc.js
@@ -92,12 +92,12 @@ const nyc = {
 
   /**
    * @summary Wraps the NPM `test` script of the Atom package with `nyc`.
-   * @return {[type]} [description]
+   * @param   {String} testScript The NPM script that runs the Atom package tests.
    */
-  run() {
+  run(testScript) {
     // We pass all env vars, because `atom --test` needs some ones for this
     // cmd to succeed (otherwise it takes `root` as user running the specs).
-    execSync('nyc npm test', { cwd, env: process.env, stdio: 'inherit' });
+    execSync(`nyc npm run ${testScript}`, { cwd, env: process.env, stdio: 'inherit' });
   },
 
   /**

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -22,6 +22,8 @@ const schema = {
       .description('The coverage tool to use to collect the coverage info'),
     transpiler: Joi.string().optional().default('babel').valid('babel')
       .description('The library/framework to use for transpiling the source files into plain JavaScript'),
+    testScript: Joi.string().optional().default('test')
+      .description('The NPM script to run the Atom package tests'),
     // Internal initialized if missing WHEN reading config through `cosmiconfig`.
     sourcesRoot: Joi.string().optional()
       .description('The root path for the source files of your project'),
@@ -31,6 +33,7 @@ const cwd = process.cwd();
 const defaults = {
   config: {
     instrumenter: 'nyc',
+    testScript: 'test',
     transpiler: 'babel',
   },
   cosmiconfig: {
@@ -167,7 +170,7 @@ const manager = {
     }
 
     // Step 3: run coverage tool.
-    this.instrumenter.run();
+    this.instrumenter.run(this.config.testScript);
   },
 
   /**

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -159,15 +159,7 @@ const manager = {
     this.transpiler.transpile(this.config);
 
     // Step 2: pre-instrument transpiled files (if needed).
-    switch (this.config.instrumenter) {
-      case 'nyc':
-        // `babel-plugin-istanbul` already instruments the source files it transpiles.
-        if (this.config.transpiler === 'babel') {
-          break;
-        }
-        break;
-      default:
-    }
+    // babel + nyc ~> babel-plugin-istanbul already instruments the source files.
 
     // Step 3: run coverage tool.
     this.instrumenter.run(this.config.testScript);

--- a/lib/transpiler/babel.js
+++ b/lib/transpiler/babel.js
@@ -142,9 +142,9 @@ const babel = {
   },
 
   /**
-   * Babel can only transpile from ES6+ into ES5, so `lang` is irrelevant here.
+   * Babel can only transpile from ES6+ into ES5.
    * Besides, it can do both tasks, transpile and instrument, if the user has
-   * selected `nyc` has coverage tool.
+   * selected `nyc` has coverage tool through the plugin `babel-plugin-istanbul`.
    *
    * @param {Object} config AtomCoverage settings.
    */

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "lodash": "^4.17.5"
   },
   "devDependencies": {
-    "@commitlint/cli": "^6.1.0",
-    "@commitlint/config-conventional": "^6.1.0",
-    "@commitlint/prompt": "^6.1.0",
-    "@commitlint/travis-cli": "^6.1.0",
+    "@commitlint/cli": "^6.1.2",
+    "@commitlint/config-conventional": "^6.1.2",
+    "@commitlint/prompt": "^6.1.2",
+    "@commitlint/travis-cli": "^6.1.2",
     "@semantic-release/npm": "^3.0.2",
     "chai": "^4.1.2",
     "chokidar-cli": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     }
   },
   "scripts": {
-    "check": "npm-run-all lint:* test:coverage check:* codeclimate",
+    "check": "npm-run-all lint:* test:coverage check:*",
     "codeclimate": "codeclimate analyze",
     "check:coverage": "nyc check-coverage",
     "dev:ide": "atom --disable-gpu -d .",

--- a/test/1-unit/manager.spec.js
+++ b/test/1-unit/manager.spec.js
@@ -472,7 +472,7 @@ describe('UNIT TESTS: manager', () => {
     ['babel', 'coffeescript'].forEach((transpiler) => {
       it(`should transpile (${transpiler}) ~> instrument ~> run tests with coverage by \`nyc\``, () => {
         // 3. Stub/spy same module functions/methods called by the UUT.
-        // FIXME Replace with coffeescript transpiler when/if supported.
+        // NOTE Replace with coffeescript transpiler when/if supported.
         manager.transpiler = stub.babel;
         manager.instrumenter = stub.nyc;
         manager.config = _.cloneDeep(data.config.atomCoverage.defaults);
@@ -490,7 +490,7 @@ describe('UNIT TESTS: manager', () => {
     it('should transpile (babel) ~> instrument ~> run tests with coverage by `blanket`', () => {
       // 3. Stub/spy same module functions/methods called by the UUT.
       manager.transpiler = stub.babel;
-      // FIXME Replace with blanket instrumenter when/if supported.
+      // NOTE Replace with blanket instrumenter when/if supported.
       manager.instrumenter = stub.nyc;
       manager.config = _.cloneDeep(data.config.atomCoverage.defaults);
       manager.config.instrumenter = 'blanket';

--- a/test/1-unit/nyc.spec.js
+++ b/test/1-unit/nyc.spec.js
@@ -227,12 +227,13 @@ describe('UNIT TESTS: nyc instrumenter', () => {
       spy = { run: sinon.spy(nyc, 'run') };
       // 4. Mock filesystem (if read/write operations present) ~> NONE
       // 5. Test!
-      nyc.run();
+      const testScript = 'custom-test';
+      nyc.run(testScript);
       // 6. Assertions.
       expect(spy.run).to.have.been.calledOnce
-        .and.returned().and.calledWith().and.have.not.thrown();
+        .and.returned().and.calledWith(testScript).and.have.not.thrown();
       expect(stub.execSync).to.have.been.calledOnce
-        .and.calledWith('nyc npm test')
+        .and.calledWith(`nyc npm run ${testScript}`)
         .and.returned().and.have.not.thrown();
       const execSyncOpts = stub.execSync.args[0][1];
       expect(execSyncOpts).to.be.an('object').that.has.all.keys('cwd', 'env', 'stdio');

--- a/test/helpers/data.js
+++ b/test/helpers/data.js
@@ -5,6 +5,7 @@
 const configFilename = '.atom-coverage';
 const defaultConfig = {
   instrumenter: 'nyc',
+  testScript: 'test',
   transpiler: 'babel',
 };
 const goodConfigFiles = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,46 +2,28 @@
 # yarn lockfile v1
 
 
-"@commitlint/cli@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-6.1.0.tgz#0a545088b4e0268cca1dca7e8ccd95bd55847b88"
+"@commitlint/cli@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-6.1.2.tgz#dc4c7507ab2dee92a821e9753556f1ac1e261883"
   dependencies:
-    "@commitlint/core" "^6.1.0"
+    "@commitlint/format" "^6.1.2"
+    "@commitlint/lint" "^6.1.2"
+    "@commitlint/load" "^6.1.2"
+    "@commitlint/read" "^6.1.2"
     babel-polyfill "6.26.0"
-    chalk "2.3.0"
+    chalk "2.3.1"
     get-stdin "5.0.1"
-    lodash.merge "4.6.0"
+    lodash.merge "4.6.1"
     lodash.pick "4.4.0"
     meow "3.7.0"
 
-"@commitlint/config-conventional@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/config-conventional/-/config-conventional-6.1.0.tgz#1f1c1577f1ca10f112e4346d9c94af1f8936f0c5"
+"@commitlint/config-conventional@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/config-conventional/-/config-conventional-6.1.2.tgz#66e328adf6051a7efb5e01c55f49bf78ebb15f08"
 
-"@commitlint/core@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/core/-/core-6.1.0.tgz#41b2482044039435cb9673995598717038f2f6d0"
-  dependencies:
-    "@commitlint/execute-rule" "^6.1.0"
-    "@commitlint/is-ignored" "^6.1.0"
-    "@commitlint/parse" "^6.1.0"
-    "@commitlint/resolve-extends" "^6.1.0"
-    "@commitlint/rules" "^6.1.0"
-    "@commitlint/top-level" "^6.1.0"
-    "@marionebl/sander" "^0.6.0"
-    babel-runtime "^6.23.0"
-    chalk "^2.0.1"
-    cosmiconfig "^4.0.0"
-    git-raw-commits "^1.3.0"
-    lodash.merge "4.6.0"
-    lodash.mergewith "4.6.0"
-    lodash.pick "4.4.0"
-    lodash.topairs "4.3.0"
-    resolve-from "4.0.0"
-
-"@commitlint/ensure@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/ensure/-/ensure-6.1.0.tgz#567f029d816b6b5ca16bf62499230324c99a8fa9"
+"@commitlint/ensure@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/ensure/-/ensure-6.1.2.tgz#c27a69e213cfbe47023261f4169559c154378c51"
   dependencies:
     lodash.camelcase "4.3.0"
     lodash.kebabcase "4.1.1"
@@ -49,34 +31,65 @@
     lodash.startcase "4.4.0"
     lodash.upperfirst "4.3.1"
 
-"@commitlint/execute-rule@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/execute-rule/-/execute-rule-6.1.0.tgz#4f56e5855a5e25ebcbc985d2209ea29f1bb89774"
+"@commitlint/execute-rule@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/execute-rule/-/execute-rule-6.1.2.tgz#ef8c7ee10726f863211d494be8e4eaf001a0e258"
   dependencies:
     babel-runtime "6.26.0"
 
-"@commitlint/is-ignored@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/is-ignored/-/is-ignored-6.1.0.tgz#0b86f8b37dfc693d6d66760b36fee1aba50882d8"
+"@commitlint/format@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/format/-/format-6.1.2.tgz#f46fa96f874369c166b420e3ed59f745c3bb3d49"
+  dependencies:
+    babel-runtime "^6.23.0"
+    chalk "^2.0.1"
+
+"@commitlint/is-ignored@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/is-ignored/-/is-ignored-6.1.2.tgz#254d5bab480823adcf4fa945cae1ea8d533262e1"
   dependencies:
     semver "5.5.0"
 
-"@commitlint/message@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/message/-/message-6.1.0.tgz#ee4ca775ad876ba59d23d02ba386c9b9038969e3"
+"@commitlint/lint@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/lint/-/lint-6.1.2.tgz#a7c5bc051eb0539d41924fb0c11af13bfe186cb2"
+  dependencies:
+    "@commitlint/is-ignored" "^6.1.2"
+    "@commitlint/parse" "^6.1.2"
+    "@commitlint/rules" "^6.1.2"
+    babel-runtime "^6.23.0"
+    lodash.topairs "4.3.0"
 
-"@commitlint/parse@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/parse/-/parse-6.1.0.tgz#e4ba58ab632371078b9b9609ae7af03c2e7b3a3e"
+"@commitlint/load@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/load/-/load-6.1.2.tgz#20d16d2fd72bd3d1ed6a22b7234b1fd55c95fbdc"
+  dependencies:
+    "@commitlint/execute-rule" "^6.1.2"
+    "@commitlint/resolve-extends" "^6.1.2"
+    babel-runtime "^6.23.0"
+    cosmiconfig "^4.0.0"
+    lodash.merge "4.6.1"
+    lodash.mergewith "4.6.1"
+    lodash.pick "4.4.0"
+    lodash.topairs "4.3.0"
+    resolve-from "4.0.0"
+
+"@commitlint/message@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/message/-/message-6.1.2.tgz#7f0f71858bae2310ab45886aeff3f8ae48483c21"
+
+"@commitlint/parse@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/parse/-/parse-6.1.2.tgz#920c82a41ac28b0169f1a5d4ad4115cefda96205"
   dependencies:
     conventional-changelog-angular "^1.3.3"
     conventional-commits-parser "^2.1.0"
 
-"@commitlint/prompt@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/prompt/-/prompt-6.1.0.tgz#8c2617050858bc16e8d5d583e27afbfcbf23eae2"
+"@commitlint/prompt@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/prompt/-/prompt-6.1.2.tgz#75fd7a913285db2b88bd5309ded0b0576740c429"
   dependencies:
-    "@commitlint/core" "^6.1.0"
+    "@commitlint/load" "^6.1.2"
     babel-runtime "^6.23.0"
     chalk "^2.0.0"
     lodash.camelcase "4.3.0"
@@ -88,41 +101,50 @@
     throat "^4.1.0"
     vorpal "^1.10.0"
 
-"@commitlint/resolve-extends@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/resolve-extends/-/resolve-extends-6.1.0.tgz#b3d92f69e3746e94de0023f8be3b1f605a20839a"
+"@commitlint/read@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/read/-/read-6.1.2.tgz#6f39d62cc120c139d075ec205ed1dbfc681f173f"
+  dependencies:
+    "@commitlint/top-level" "^6.1.2"
+    "@marionebl/sander" "^0.6.0"
+    babel-runtime "^6.23.0"
+    git-raw-commits "^1.3.0"
+
+"@commitlint/resolve-extends@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/resolve-extends/-/resolve-extends-6.1.2.tgz#b48b7195243dc9381bcf341c2fcb6b1e803da8b4"
   dependencies:
     babel-runtime "6.26.0"
-    lodash.merge "4.6.0"
+    lodash.merge "4.6.1"
     lodash.omit "4.5.0"
     require-uncached "^1.0.3"
     resolve-from "^4.0.0"
     resolve-global "^0.1.0"
 
-"@commitlint/rules@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/rules/-/rules-6.1.0.tgz#564b69503a3a4d09d03a9a077731c9655ee8f4df"
+"@commitlint/rules@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/rules/-/rules-6.1.2.tgz#2ceffa7bf69d1fe327bcb178f7a71bd4e094e355"
   dependencies:
-    "@commitlint/ensure" "^6.1.0"
-    "@commitlint/message" "^6.1.0"
-    "@commitlint/to-lines" "^6.1.0"
+    "@commitlint/ensure" "^6.1.2"
+    "@commitlint/message" "^6.1.2"
+    "@commitlint/to-lines" "^6.1.2"
     babel-runtime "^6.23.0"
 
-"@commitlint/to-lines@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/to-lines/-/to-lines-6.1.0.tgz#9e130254c980dbd456e1693df1082a77ba7114a0"
+"@commitlint/to-lines@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/to-lines/-/to-lines-6.1.2.tgz#01d0272fe98a530e6538ef934f970aeae3fa498c"
 
-"@commitlint/top-level@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/top-level/-/top-level-6.1.0.tgz#b420c1e9166df3afa000186a42b7f49cae4014cc"
+"@commitlint/top-level@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/top-level/-/top-level-6.1.2.tgz#280c179afc517d2a58c1c79aa5019edffa5d443d"
   dependencies:
     find-up "^2.1.0"
 
-"@commitlint/travis-cli@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/travis-cli/-/travis-cli-6.1.0.tgz#85bc5c251cba58e29cbfb62c7054b3d61a739254"
+"@commitlint/travis-cli@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/travis-cli/-/travis-cli-6.1.2.tgz#e87cf3116c755febdc465d74d10d88e1610cf389"
   dependencies:
-    "@commitlint/cli" "^6.1.0"
+    "@commitlint/cli" "^6.1.2"
     babel-runtime "6.26.0"
     execa "0.9.0"
 
@@ -710,7 +732,15 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@2.3.0, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
+chalk@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
+  dependencies:
+    ansi-styles "^3.2.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.2.0"
+
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
@@ -2837,13 +2867,13 @@ lodash.map@^4.5.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
 
-lodash.merge@4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+lodash.merge@4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
 
-lodash.mergewith@4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
+lodash.mergewith@4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
 
 lodash.omit@4.5.0:
   version "4.5.0"
@@ -4438,6 +4468,12 @@ supports-color@^4.0.0:
 supports-color@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
+  dependencies:
+    has-flag "^3.0.0"
+
+supports-color@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
   dependencies:
     has-flag "^3.0.0"
 


### PR DESCRIPTION
Preparing next release:

- [x] Rewrite `README.md` to keep it shorter and sweeter.
- [x] Change FIXME comments to NOTE in tests.
- [x] Upgrade dependencies.
- [x] Mute `eslint-plugin-json` issue on bitHound, since it's due to `shelljs` deep dependency, which it's impossible to fix currently.
- [x] Adhere to contributor covenant code of conduct.
- [x] Document in `README.md` the support for `atom-coverage` configuration through config file or `package.json` property.
- [x] Support a new option to customize the NPM test script (currently always defaults to `test`).
- [x] Fix `semantic-release` changelog auto-generation (currently not auto-generating!).
